### PR TITLE
Handle session-uri in body

### DIFF
--- a/sushy/main.py
+++ b/sushy/main.py
@@ -453,6 +453,13 @@ class Sushy(base.ResourceBase):
 
         session_uri = rsp.headers.get('Location')
         if session_uri is None:
+            try:
+                body = rsp.json()
+                session_uri = body.get("@odata.id")
+            except ValueError:  # JSON decoding failed
+                pass
+
+        if session_uri is None:
             LOG.warning("Received X-Auth-Token but NO session uri.")
 
         return session_key, session_uri


### PR DESCRIPTION
The Cisco CIMC 4.1(2b) and potentially others do not set the Location header as required by the Redfish standard on a successful login, but return a session object as a body.

By taking the session-uri out of the body,
we avoid leaking sessions in that situation.

Change-Id: I3dbf80f3383c51d3e754516529471698851bf573